### PR TITLE
feat: add OverlayBackground control for UI overlay

### DIFF
--- a/rc-car-maui-app/Controls/OverlayBackground.xaml
+++ b/rc-car-maui-app/Controls/OverlayBackground.xaml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<Border
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    x:Class="rc_car_maui_app.Controls.OverlayBackground"
+    BackgroundColor="#66000000"
+    StrokeThickness="0"
+    StrokeShape="RoundRectangle 10"
+    VerticalOptions="Center"
+    HorizontalOptions="Center">
+    
+    <ContentPresenter />
+</Border>

--- a/rc-car-maui-app/Controls/OverlayBackground.xaml.cs
+++ b/rc-car-maui-app/Controls/OverlayBackground.xaml.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace rc_car_maui_app.Controls;
+
+public partial class OverlayBackground : Border
+{
+    public OverlayBackground()
+    {
+        InitializeComponent();
+    }
+}


### PR DESCRIPTION
At default the background is a rectangle with rounded corners. But it is also possible to make it a circle for example by passing the param StrokeShape="Ellipse" when using it. Example:

```
<controls:OverlayBackground StrokeShape="Ellipse">
    # Here goes the content inside the container
</controls:OverlayBackground>
```