### PR TITLE
setting manually change dark/light mode

### DIFF
--- a/rc-car-maui-app/App.xaml.cs
+++ b/rc-car-maui-app/App.xaml.cs
@@ -2,9 +2,10 @@
 
 public partial class App : Application
 {
-    public App()
+    public App(IThemeService themeService)
     {
         InitializeComponent();
+        themeService.ApplySaved();
     }
 
     protected override Window CreateWindow(IActivationState? activationState)

--- a/rc-car-maui-app/Helpers/ServiceHelper.cs
+++ b/rc-car-maui-app/Helpers/ServiceHelper.cs
@@ -1,0 +1,7 @@
+using Microsoft.Extensions.DependencyInjection;
+
+public static class ServiceHelper
+{
+    public static T GetService<T>() where T : notnull =>
+        Application.Current!.Handler!.MauiContext!.Services.GetRequiredService<T>();
+}

--- a/rc-car-maui-app/MauiProgram.cs
+++ b/rc-car-maui-app/MauiProgram.cs
@@ -14,6 +14,8 @@ public static class MauiProgram
                 fonts.AddFont("OpenSans-Regular.ttf", "OpenSansRegular");
                 fonts.AddFont("OpenSans-Semibold.ttf", "OpenSansSemibold");
             });
+        builder.Services.AddSingleton<IThemeService, ThemeService>();
+
 
 #if ANDROID
         Microsoft.Maui.Handlers.WebViewHandler.Mapper.AppendToMapping("MyZoomSettings", (handler, view) =>

--- a/rc-car-maui-app/Services/IThemeService.cs
+++ b/rc-car-maui-app/Services/IThemeService.cs
@@ -1,0 +1,9 @@
+public enum ThemeSetting { Light, Dark }
+
+public interface IThemeService
+{
+    ThemeSetting GetSaved();
+    void Apply(ThemeSetting setting);
+    void Save(ThemeSetting setting);
+    void ApplySaved();
+}

--- a/rc-car-maui-app/Services/ThemeService.cs
+++ b/rc-car-maui-app/Services/ThemeService.cs
@@ -1,0 +1,25 @@
+using Microsoft.Maui.Storage;
+
+public sealed class ThemeService : IThemeService
+{
+    private const string ThemeKey = "app_theme";
+
+    public ThemeSetting GetSaved()
+    {
+        var raw = Preferences.Get(ThemeKey, "Light");
+        return raw == "Dark" ? ThemeSetting.Dark : ThemeSetting.Light;
+    }
+
+    public void Apply(ThemeSetting setting)
+    {
+        Application.Current!.UserAppTheme =
+            setting == ThemeSetting.Dark ? AppTheme.Dark : AppTheme.Light;
+    }
+
+    public void Save(ThemeSetting setting)
+    {
+        Preferences.Set(ThemeKey, setting == ThemeSetting.Dark ? "Dark" : "Light");
+    }
+
+    public void ApplySaved() => Apply(GetSaved());
+}

--- a/rc-car-maui-app/Views/SettingsPage.xaml
+++ b/rc-car-maui-app/Views/SettingsPage.xaml
@@ -111,7 +111,7 @@
                                Grid.Column="0"/>
                         
                         <customSwitch:CustomSwitch
-                            IsToggled="True"
+                            x:Name="DarkModeSwitch"
                             Toggled="OnDarkModeToggled"
                             HorizontalOptions="End"
                             Grid.Column="1"/>

--- a/rc-car-maui-app/Views/SettingsPage.xaml.cs
+++ b/rc-car-maui-app/Views/SettingsPage.xaml.cs
@@ -4,9 +4,20 @@ namespace rc_car_maui_app.Views;
 
 public partial class SettingsPage : ContentPage
 {
+
+    private readonly IThemeService _theme;
+    private bool _initializing;
+    
     public SettingsPage()
     {
         InitializeComponent();
+        
+        _theme = ServiceHelper.GetService<IThemeService>();
+
+        // Switch auf gespeicherten Zustand setzen, Event dabei ignorieren
+        _initializing = true;
+        DarkModeSwitch.IsToggled = _theme.GetSaved() == ThemeSetting.Dark;
+        _initializing = false;
     }
     
     private void OnUnitToggled(object sender, ToggledEventArgs e)
@@ -66,13 +77,9 @@ public partial class SettingsPage : ContentPage
     
     private void OnDarkModeToggled(object sender, ToggledEventArgs e)
     {
-        if (e.Value)
-        {
-            Console.WriteLine("Dark Mode");
-        }
-        else
-        {
-            Console.WriteLine("Light Mode");
-        }
+        if (_initializing) return;
+        var setting = e.Value ? ThemeSetting.Dark : ThemeSetting.Light;
+        _theme.Apply(setting);   // sofort umschalten
+        _theme.Save(setting);    // speichern
     }
 }


### PR DESCRIPTION
Added ThemeService (IThemeService + ThemeService) to apply & save theme.
Registered service in MauiProgram.cs.
Applied saved theme on app startup (App.xaml.cs).
Added ServiceHelper to access DI services in XAML pages.
Initializes from saved preference.
Applies theme immediately on toggle.
Persists user choice across restarts.