### PR TITLE
hotfix: duplicated OnAppearing method

### DIFF
--- a/rc-car-maui-app/Views/SettingsPage.xaml.cs
+++ b/rc-car-maui-app/Views/SettingsPage.xaml.cs
@@ -21,6 +21,13 @@ public partial class SettingsPage : ContentPage
         BatterySwitch.IsToggled = enabled;
         _initBattery = false;
         
+        LanguagePicker.SelectedIndex = Localization.CurrentCode switch
+        {
+            "de" => 1,
+            "es" => 2,
+            _    => 0
+        };
+        
     }
     public SettingsPage()
     {
@@ -80,16 +87,6 @@ public partial class SettingsPage : ContentPage
         Preferences.Set("AppLanguage", code);
         Localization.SetCulture(code);  
 
-    }
-    protected override void OnAppearing()
-    {
-        base.OnAppearing();
-        LanguagePicker.SelectedIndex = Localization.CurrentCode switch
-        {
-            "de" => 1,
-            "es" => 2,
-            _    => 0
-        };
     }
 
     private void OnDarkModeToggled(object sender, ToggledEventArgs e)


### PR DESCRIPTION
After merging PR #80 into main, the app couldn't start normally due to duplicated OnAppearing method.
This was hotfix by packing content from another OnAppearing method, into one single method.

I've tested it and it now works normally, but for 100% sure please test it again if everything work as expected.

